### PR TITLE
Updated style-guide repo reference to Digital-First-Specifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,4 +86,4 @@ Security issues should be reported directly to Katherine Dease kdease@irionline.
 
 ## Code of conduct
 
-See [style guide](https://github.com/Insured-Retirement-Institute/Style-Guide)
+See [Digital-First-Specifications](https://github.com/Insured-Retirement-Institute/Digital-First-Specifications) repository


### PR DESCRIPTION
As part of the impending name change of the `Style-Guide` repo to `Digital-First-Specifications`, I updated the repository links in the README